### PR TITLE
Cast int to int64

### DIFF
--- a/nutanix/services/volumesv2/resource_nutanix_volume_group_disk_v2.go
+++ b/nutanix/services/volumesv2/resource_nutanix_volume_group_disk_v2.go
@@ -230,7 +230,7 @@ func ResourceNutanixVolumeGroupDiskV2Update(ctx context.Context, d *schema.Resou
 		updateSpec.Index = nil
 	}
 	if d.HasChange("disk_size_bytes") {
-		diskSizeBytes := d.Get("disk_size_bytes").(int64)
+		diskSizeBytes := int64(d.Get("disk_size_bytes").(int))
 		updateSpec.DiskSizeBytes = &diskSizeBytes
 	}
 	if d.HasChange("description") {


### PR DESCRIPTION
Fixes #839

The terraform-plugin-sdk will always return an int when specifying TypeInt in the schema, which is what happens for disk_size_bytes: https://github.com/nutanix/terraform-provider-nutanix/blob/cac904185e71c26769a3f1ac7e3a9fbad677c8d6/nutanix/services/volumesv2/resource_nutanix_volume_group_disk_v2.go#L48

TypeInt source: 
https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/schema/field_reader.go#L316

